### PR TITLE
Fix running on linux

### DIFF
--- a/Sources/PackageConfig/Package.swift
+++ b/Sources/PackageConfig/Package.swift
@@ -1,8 +1,4 @@
-
-import class Foundation.Process
-import class Foundation.Pipe
-import class Foundation.FileHandle
-import class Foundation.FileManager
+import Foundation
 
 enum Package {
 	
@@ -120,14 +116,26 @@ enum Package {
             return nil
         }
 
-        guard let version = contents.components(separatedBy: "\n").first?.components(separatedBy: ":").last else {
+        let range = NSRange(location: 0, length: contents.count)
+        guard let regex = try? NSRegularExpression(pattern: #"^// swift-tools-version:(?:(\d)\.(\d)(?:\.\d)?)$"#) else {
             return nil
         }
         
-        let semverParts = version.components(separatedBy: ".").map { Int($0) }
-        switch semverParts[0] {
+        guard let match = regex.firstMatch(in: contents, options: [], range: range) else {
+            return nil
+        }
+        
+        guard let majorRange = Range(match.range(at: 1), in: contents), let major = Int(contents[majorRange]) else {
+            return nil
+        }
+        
+        guard let minorRange = Range(match.range(at: 2), in: contents), let minor = Int(contents[minorRange]) else {
+            return nil
+        }
+        
+        switch major {
         case 4:
-            if semverParts[1]! < 2 {
+            if minor < 2 {
                 return "4"
             }
             return "4_2"

--- a/Sources/PackageConfig/Package.swift
+++ b/Sources/PackageConfig/Package.swift
@@ -1,115 +1,115 @@
 import Foundation
 
 enum Package {
-	
-	static func compile() throws {
-		let swiftC = try findPath(tool: "swiftc")
-		let process = Process()
-		let linkedLibraries = try libraryLinkingArguments()
-		var arguments = [String]()
-			arguments += ["--driver-mode=swift"] // Eval in swift mode, I think?
-			arguments += getSwiftPMManifestArgs(swiftPath: swiftC) // SwiftPM lib
-			arguments += linkedLibraries
-			arguments += ["-suppress-warnings"] // SPM does that too
-		 	arguments += ["Package.swift"] // The Package.swift in the CWD
 
-		// Create a process to eval the Swift Package manifest as a subprocess
-		process.launchPath = swiftC
-		process.arguments = arguments
-		process.standardOutput = FileHandle.standardOutput
-		process.standardError = FileHandle.standardOutput
+    static func compile() throws {
+        let swiftC = try findPath(tool: "swiftc")
+        let process = Process()
+        let linkedLibraries = try libraryLinkingArguments()
+        var arguments = [String]()
+            arguments += ["--driver-mode=swift"] // Eval in swift mode, I think?
+            arguments += getSwiftPMManifestArgs(swiftPath: swiftC) // SwiftPM lib
+            arguments += linkedLibraries
+            arguments += ["-suppress-warnings"] // SPM does that too
+             arguments += ["Package.swift"] // The Package.swift in the CWD
 
-		debugLog("CMD: \(swiftC) \( arguments.joined(separator: " "))")
+        // Create a process to eval the Swift Package manifest as a subprocess
+        process.launchPath = swiftC
+        process.arguments = arguments
+        process.standardOutput = FileHandle.standardOutput
+        process.standardError = FileHandle.standardOutput
 
-		// Evaluation of the package swift code will end up
-		// creating a file in the tmpdir that stores the JSON
-		// settings when a new instance of PackageConfig is created
-		process.launch()
-		process.waitUntilExit()
-		debugLog("Finished launching swiftc")
-	}
+        debugLog("CMD: \(swiftC) \( arguments.joined(separator: " "))")
 
-	static private func findPath(tool: String) throws -> String {
-		let process = Process()
-		let pipe = Pipe()
+        // Evaluation of the package swift code will end up
+        // creating a file in the tmpdir that stores the JSON
+        // settings when a new instance of PackageConfig is created
+        process.launch()
+        process.waitUntilExit()
+        debugLog("Finished launching swiftc")
+    }
 
-		process.launchPath = "/bin/bash"
-		process.arguments = ["-c", "command -v \(tool)"]
-		process.standardOutput = pipe
+    static private func findPath(tool: String) throws -> String {
+        let process = Process()
+        let pipe = Pipe()
 
-		debugLog("CMD: \(process.launchPath!) \(process.arguments!.joined(separator: " "))")
+        process.launchPath = "/bin/bash"
+        process.arguments = ["-c", "command -v \(tool)"]
+        process.standardOutput = pipe
 
-		process.launch()
-		process.waitUntilExit()
-		return String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)!
-			.trimmingCharacters(in: .whitespacesAndNewlines)
-	}
+        debugLog("CMD: \(process.launchPath!) \(process.arguments!.joined(separator: " "))")
 
-	static private func libraryPath(for library: String) -> String? {
-		let fileManager = FileManager.default
-		let libPaths = [
-			".build/debug",
-			".build/x86_64-unknown-linux/debug",
-			".build/release",
-		]
+        process.launch()
+        process.waitUntilExit()
+        return String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)!
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 
-		#warning("needs to be improved")
-		#warning("consider adding `/usr/lib` to libPath maybe")
+    static private func libraryPath(for library: String) -> String? {
+        let fileManager = FileManager.default
+        let libPaths = [
+            ".build/debug",
+            ".build/x86_64-unknown-linux/debug",
+            ".build/release",
+        ]
 
-		func isLibPath(path: String) -> Bool {
-			return fileManager.fileExists(atPath: path + "/lib\(library).dylib") || // macOS
-				fileManager.fileExists(atPath: path + "/lib\(library).so") // Linux
-		}
+        #warning("needs to be improved")
+        #warning("consider adding `/usr/lib` to libPath maybe")
 
-		return libPaths.first(where: isLibPath)
-	}
+        func isLibPath(path: String) -> Bool {
+            return fileManager.fileExists(atPath: path + "/lib\(library).dylib") || // macOS
+                fileManager.fileExists(atPath: path + "/lib\(library).so") // Linux
+        }
 
-	static private func libraryLinkingArguments() throws -> [String] {
+        return libPaths.first(where: isLibPath)
+    }
+
+    static private func libraryLinkingArguments() throws -> [String] {
         let packageConfigLib = "PackageConfig"
         guard let packageConfigPath = libraryPath(for: packageConfigLib) else {
             throw Error("PackageConfig: Could not find lib\(packageConfigLib) to link against, is it possible you've not built yet?")
         }
-        
-		return try DynamicLibraries.list().map { libraryName in
-			guard let path = libraryPath(for: libraryName) else {
-				throw Error("PackageConfig: Could not find lib\(libraryName) to link against, is it possible you've not built yet?")
-			}
 
-			return [
-				"-L", path,
-				"-I", path,
-				"-l\(libraryName)"
-			]
+        return try DynamicLibraries.list().map { libraryName in
+            guard let path = libraryPath(for: libraryName) else {
+                throw Error("PackageConfig: Could not find lib\(libraryName) to link against, is it possible you've not built yet?")
+            }
+
+            return [
+                "-L", path,
+                "-I", path,
+                "-l\(libraryName)"
+            ]
         }.reduce([
             "-L", packageConfigPath,
             "-I", packageConfigPath,
             "-l\(packageConfigLib)"
         ], +)
     }
-	
 
-	static private func getSwiftPMManifestArgs(swiftPath: String) -> [String] {
-		// using "xcrun --find swift" we get
-		// /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc
-		// we need to transform it to something like:
-		// /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/4_2
-		let fileManager = FileManager.default
 
-		let swiftPMDir = swiftPath.replacingOccurrences(of: "bin/swiftc", with: "lib/swift/pm")
-		let versions = try! fileManager.contentsOfDirectory(atPath: swiftPMDir).filter { $0 != "llbuild" }
+    static private func getSwiftPMManifestArgs(swiftPath: String) -> [String] {
+        // using "xcrun --find swift" we get
+        // /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc
+        // we need to transform it to something like:
+        // /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/4_2
+        let fileManager = FileManager.default
+
+        let swiftPMDir = swiftPath.replacingOccurrences(of: "bin/swiftc", with: "lib/swift/pm")
+        let versions = try! fileManager.contentsOfDirectory(atPath: swiftPMDir).filter { $0 != "llbuild" }
 
         let latestVersion = versions.sorted().last!
         var spmVersionDir = latestVersion
-        
+
         if let swiftToolsVersion = getSwiftToolsVersion(), versions.contains(swiftToolsVersion) {
             spmVersionDir = swiftToolsVersion
         }
-        
-		let libraryPathSPM = swiftPMDir + "/" + spmVersionDir
 
-		debugLog("Using SPM version: \(libraryPathSPM)")
-		return ["-L", libraryPathSPM, "-I", libraryPathSPM, "-lPackageDescription"]
-	}
+        let libraryPathSPM = swiftPMDir + "/" + spmVersionDir
+
+        debugLog("Using SPM version: \(libraryPathSPM)")
+        return ["-L", libraryPathSPM, "-I", libraryPathSPM, "-lPackageDescription"]
+    }
     
     static private func getSwiftToolsVersion() -> String? {
         guard let contents = try? String(contentsOfFile: "Package.swift") else {
@@ -120,19 +120,19 @@ enum Package {
         guard let regex = try? NSRegularExpression(pattern: #"^// swift-tools-version:(?:(\d)\.(\d)(?:\.\d)?)$"#) else {
             return nil
         }
-        
+
         guard let match = regex.firstMatch(in: contents, options: [], range: range) else {
             return nil
         }
-        
+
         guard let majorRange = Range(match.range(at: 1), in: contents), let major = Int(contents[majorRange]) else {
             return nil
         }
-        
+
         guard let minorRange = Range(match.range(at: 2), in: contents), let minor = Int(contents[minorRange]) else {
             return nil
         }
-        
+
         switch major {
         case 4:
             if minor < 2 {

--- a/Sources/PackageConfig/Package.swift
+++ b/Sources/PackageConfig/Package.swift
@@ -7,7 +7,7 @@ import class Foundation.FileManager
 enum Package {
 	
 	static func compile() throws {
-		let swiftC = try runXCRun(tool: "swiftc")
+		let swiftC = try findPath(tool: "swiftc")
 		let process = Process()
 		let linkedLibraries = try libraryLinkingArguments()
 		var arguments = [String]()
@@ -33,15 +33,15 @@ enum Package {
 		debugLog("Finished launching swiftc")
 	}
 
-	static private func runXCRun(tool: String) throws -> String {
+	static private func findPath(tool: String) throws -> String {
 		let process = Process()
 		let pipe = Pipe()
 
-		process.launchPath = "/usr/bin/xcrun"
-		process.arguments = ["--find", tool]
+		process.launchPath = "/bin/bash"
+		process.arguments = ["-c", "command -v \(tool)"]
 		process.standardOutput = pipe
 
-		debugLog("CMD: \(process.launchPath!) \( ["--find", tool].joined(separator: " "))")
+		debugLog("CMD: \(process.launchPath!) \(process.arguments!.joined(separator: " "))")
 
 		process.launch()
 		process.waitUntilExit()


### PR DESCRIPTION
* Use `command -v` to get `swiftc` path instead of `xcrun` since `xcrun` isn't available on linux.
* On linux there is a `llbuild` directory at `lib/swift/pm` so filter it out when resolving the `PackageDescription` library path.
* Try using swift tools version specified in `Package.swift`  when resolving library path, otherwise default to latest available.

Closes #6 