### PR TITLE
Fix argument missing -package-description-version

### DIFF
--- a/Sources/PackageConfig/Package.swift
+++ b/Sources/PackageConfig/Package.swift
@@ -126,7 +126,7 @@ enum Package {
         let libraryPathSPM = swiftPMDir + "/" + spmVersionDir
 
         debugLog("Using SPM version: \(libraryPathSPM)")
-        return ["-L", libraryPathSPM, "-I", libraryPathSPM, "-lPackageDescription", "--package-description-version", getSwiftToolsVersion() ?? "5"]
+        return ["-L", libraryPathSPM, "-I", libraryPathSPM, "-lPackageDescription", "-package-description-version", getSwiftToolsVersion() ?? "5"]
     }
 
     private static func getSwiftToolsVersion() -> String? {

--- a/Sources/PackageConfig/Package.swift
+++ b/Sources/PackageConfig/Package.swift
@@ -126,7 +126,7 @@ enum Package {
         let libraryPathSPM = swiftPMDir + "/" + spmVersionDir
 
         debugLog("Using SPM version: \(libraryPathSPM)")
-        return ["-L", libraryPathSPM, "-I", libraryPathSPM, "-lPackageDescription"]
+        return ["-L", libraryPathSPM, "-I", libraryPathSPM, "-lPackageDescription", "--package-description-version", getSwiftToolsVersion() ?? "5"]
     }
 
     private static func getSwiftToolsVersion() -> String? {


### PR DESCRIPTION
It seems that since Xcode 11, `-package-description-version` is required in order to compile the `Package.swift` file. I've added the argument and a "safe" fallback (that might be changed for another one more secure). Fixes #11 