### PR TITLE
Get swift tool version only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ matrix:
       script:
         - swift build
         - swift run package-config-example --verbose
+        
+    - os: osx
+      osx_image: xcode11
+      script:
+        - swift build
+        - swift run package-config-example --verbose
 
     - os: linux
       language: generic

--- a/Sources/PackageConfig/Package.swift
+++ b/Sources/PackageConfig/Package.swift
@@ -118,15 +118,16 @@ enum Package {
 
         let latestVersion = versions.sorted().last!
         var spmVersionDir = latestVersion
+        let swiftToolsVersion = getSwiftToolsVersion()
 
-        if let swiftToolsVersion = getSwiftToolsVersion(), versions.contains(swiftToolsVersion) {
+        if let swiftToolsVersion = swiftToolsVersion, versions.contains(swiftToolsVersion) {
             spmVersionDir = swiftToolsVersion
         }
 
         let libraryPathSPM = swiftPMDir + "/" + spmVersionDir
 
         debugLog("Using SPM version: \(libraryPathSPM)")
-        return ["-L", libraryPathSPM, "-I", libraryPathSPM, "-lPackageDescription", "-package-description-version", getSwiftToolsVersion() ?? "5"]
+        return ["-L", libraryPathSPM, "-I", libraryPathSPM, "-lPackageDescription", "-package-description-version", swiftToolsVersion ?? "5"]
     }
 
     private static func getSwiftToolsVersion() -> String? {


### PR DESCRIPTION
`getSwiftToolsVersion` uses a regex, then is better to get it only once and reuse it