### PR TITLE
Fix warning for deprecated method.

### DIFF
--- a/Sources/PackageConfig/DynamicLibraries.swift
+++ b/Sources/PackageConfig/DynamicLibraries.swift
@@ -43,7 +43,7 @@ enum DynamicLibraries {
 			.map(String.init)
 			.map {
 				guard let comment = $0.range(of: "//")?.lowerBound else { return $0 }
-				return String($0.prefix(comment.encodedOffset))
+				return String($0[..<comment])
 			}
 			.joined()
 			.replacingOccurrences(of: "\t", with: "")


### PR DESCRIPTION
This PR fixes the warning for using `encodedOffset`, using the String index directly instead. Fixes #16.