### PR TITLE
Use correct swift package manager version

### DIFF
--- a/Sources/PackageConfig/Package.swift
+++ b/Sources/PackageConfig/Package.swift
@@ -120,18 +120,19 @@ enum Package {
         var spmVersionDir = latestVersion
         let swiftToolsVersion = getSwiftToolsVersion()
 
-        if let swiftToolsVersion = swiftToolsVersion, versions.contains(swiftToolsVersion) {
+        if let swiftToolsVersion = swiftToolsVersion.map({ folderPath(minor: $0.minor, major: $0.major) }),
+            versions.contains(swiftToolsVersion) {
             spmVersionDir = swiftToolsVersion
         }
 
-        let packageDescriptionVersion = swiftToolsVersion?.replacingOccurrences(of: "_", with: ".")
+        let packageDescriptionVersion = swiftToolsVersion.map { "\($0.major).\($0.minor)" }
         let libraryPathSPM = swiftPMDir + "/" + spmVersionDir
 
         debugLog("Using SPM version: \(libraryPathSPM)")
         return ["-L", libraryPathSPM, "-I", libraryPathSPM, "-lPackageDescription", "-package-description-version", packageDescriptionVersion ?? "5.2"]
     }
 
-    private static func getSwiftToolsVersion() -> String? {
+    private static func getSwiftToolsVersion() -> PackageVersion? {
         guard let contents = try? String(contentsOfFile: "Package.swift") else {
             return nil
         }
@@ -145,14 +146,19 @@ enum Package {
             return nil
         }
 
-        switch major {
-        case 4:
-            if minor < 2 {
-                return "4"
-            }
+        return PackageVersion(minor: minor, major: major)
+    }
+    
+    private static func folderPath(minor: Int, major: Int) -> String {
+        if major == 4 && minor < 2 {
+            return "4"
+        } else {
             return "4_2"
-        default:
-            return "\(major)_\(minor)"
         }
+    }
+    
+    struct PackageVersion {
+        let minor: Int
+        let major: Int
     }
 }


### PR DESCRIPTION
I've separated the logic to find the folder (which seems to be always at `lib/swift/pm/4_2/`), and the version used to compile the `Package.swift` which depends on the version specified on the `swift-tools-version`.
