### PR TITLE
Fix building for Xcode 13 and Swift 5.5

### DIFF
--- a/Sources/PackageConfig/Package.swift
+++ b/Sources/PackageConfig/Package.swift
@@ -114,7 +114,9 @@ enum Package {
         let fileManager = FileManager.default
 
         let swiftPMDir = swiftPath.replacingOccurrences(of: "bin/swiftc", with: "lib/swift/pm")
-        let versions = try! fileManager.contentsOfDirectory(atPath: swiftPMDir).filter { $0 != "llbuild" }
+        let versions = try! fileManager.contentsOfDirectory(atPath: swiftPMDir)
+            .filter { $0 != "llbuild" }
+            .filter { $0.first?.isNumber ?? false }
 
         let latestVersion = versions.sorted().last!
         var spmVersionDir = latestVersion


### PR DESCRIPTION
So the issue is that in Xcode 13 there are new contents where before just were two directories to the different libPackageDescription like so:

![image](https://user-images.githubusercontent.com/3819883/135089644-cca1d568-b6bc-4483-86a7-87a729cda8c8.png)

The PR just filters out every folder or content that is not starting with a number, which will make the trick for a long time IMHO.

Thanks @orta for the guidance.

Fixes #20 