### PR TITLE
Fixed behaviour for binary Package compilation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,13 +28,13 @@ let package = Package(
 #if canImport(ExampleConfig)
 import ExampleConfig
 
-ExampleConfig(value: "example value").write()
+let example = ExampleConfig(value: "example value").write()
 #endif
 
 #if canImport(PackageConfig)
 import PackageConfig
 
-PackageConfiguration(["example": [
+let config = PackageConfiguration(["example": [
     ["example1": ""],
     "example2",
     3

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ At the very bottom of the `Package.swift`
 import ExampleConfig
 
 // invoking write is mandatory, otherwise the config won't be written // thanks captain obvious
-ExampleConfig(value: "example value").write()
+let exampleConfig = ExampleConfig(value: "example value").write()
 #endif
 ```
 
@@ -79,7 +79,7 @@ If more than one dependency uses `PackageConfig` be sure to wrap each in
 #if canImport(SomeLibraryConfig)
 import SomeLibraryConfig
 
-SomeLibraryConfig().write()
+let someLibraryConfig = SomeLibraryConfig().write()
 #endif
 ```
 
@@ -169,7 +169,7 @@ Since `YourConfig` target is a dynamic library you must ensure that you have bui
   let config = PackageConfig([
       "danger" : ["disable"],
       "linter": ["rules": ["allowSomething"]]
-  ])
+  ]).write()
   #endif
   ```
 

--- a/Sources/PackageConfig/PackageConfig.swift
+++ b/Sources/PackageConfig/PackageConfig.swift
@@ -11,6 +11,8 @@ extension PackageConfig {
 
 	public static func load() throws -> Self {
 		try Package.compile()
+        try Package.otool()
+        try Package.runIfNeeded()
 		return try Loader.load()
 	}
 


### PR DESCRIPTION
With the release of Xcode 13 and Swift 5.5, it seems that there have been some changes into how `swiftc` behaves when parsing the `Package.swift` file, generating a binary with many dynamic libraries to be linked before being executed, using `otool` and `install_name_tool` we inject the new paths where the binary can find its dynamic libraries. This PR covers that change. Feel free to test it. 

Tested with: Swift 5.5
- PackageConfig
- Komondor

Sorry for the amount of PRs @orta and for your valuable time. 