### PR TITLE
Simplify dynamic linking process

### DIFF
--- a/Sources/PackageConfig/PackageConfig.swift
+++ b/Sources/PackageConfig/PackageConfig.swift
@@ -11,7 +11,6 @@ extension PackageConfig {
 
 	public static func load() throws -> Self {
 		try Package.compile()
-        try Package.otool()
         try Package.runIfNeeded()
 		return try Loader.load()
 	}


### PR DESCRIPTION
Before I used `install_name_tool` to statically link all libraries that were dynamic. Now just I compile the binary with `-Xlinker` flags to let the executable load dynamically those libraries searching them in the corresponding directories, which is the correct approach for swift compiling processes.