### PR TITLE
Allow to link dynamic libraries when importing *Config modules

### DIFF
--- a/Sources/PackageConfig/DynamicLibraries.swift
+++ b/Sources/PackageConfig/DynamicLibraries.swift
@@ -1,6 +1,8 @@
 
 import class Foundation.Process
 import class Foundation.Pipe
+import class Foundation.NSRegularExpression
+import struct Foundation.NSRange
 
 enum DynamicLibraries {
 
@@ -55,4 +57,24 @@ enum DynamicLibraries {
 			.replacingOccurrences(of: "\"\"", with: "\"")
 			.split(separator: "\"").map(String.init)
 	}
+    
+    static func listImports() -> [String] {
+        let lines = read()
+        
+        var matches: [String] = []
+
+        for line in lines {
+            if let match = line.range(of: "import .*Config", options: .regularExpression) {
+                matches.append(String(line[match]))
+            }
+        }
+        
+        debugLog("MATCHES: \(matches)")
+        
+        return matches
+            .compactMap { $0.split(separator: " ") }
+            .compactMap { $0.last }
+            .map(String.init)
+            .filter { !$0.contains("PackageDescription") }
+    }
 }


### PR DESCRIPTION
This PR allows users to create their own dynamic libraries with custom `PackageConfiguration` extensions which makes it compatible with libraries such as Komondor and Rocket.

The change is pretty simple, when compiling `Package.swift`, PackageConfig will look for any module import that ends with `*Config`, i.e. `import MyCustomHooksConfig`. In a similar way which PackageConfigs method works but it allows to create libraries that can be used by third-party packages as well. 