### PR TITLE
Rename Example product to avoid duplication with another libraries

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
 		.executable(name: "package-config", targets: ["PackageConfigExecutable"]), // dev
 
 		.library(name: "ExampleConfig", type: .dynamic, targets: ["ExampleConfig"]), // dev
-		.executable(name: "package-config-example", targets: ["Example"]), // dev
+		.executable(name: "package-config-example", targets: ["ExampleMain"]), // dev
     ],
     dependencies: [
     ],
@@ -19,7 +19,7 @@ let package = Package(
 		.target(name: "PackageConfigExecutable", dependencies: []), // dev
 
 		.target(name: "ExampleConfig", dependencies: ["PackageConfig"]), // dev
-		.target(name: "Example", dependencies: ["PackageConfig", "ExampleConfig"]), // dev
+		.target(name: "ExampleMain", dependencies: ["PackageConfig", "ExampleConfig"]), // dev
 
 		.target(name: "PackageConfigs", dependencies: ["ExampleConfig"]), // dev
     ]

--- a/Sources/ExampleMain/main.swift
+++ b/Sources/ExampleMain/main.swift
@@ -1,4 +1,3 @@
-
 import struct ExampleConfig.ExampleConfig
 
 do {


### PR DESCRIPTION
Swift Package Manager raises an error when it finds two packages that has the same product name (even if it is not used at all in the project), so better to find a more specific name for it. Fixes #15 